### PR TITLE
Fix/liq accounting

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
   libs = ["lib"]
   optimizer = true
-  optimizer_runs = 1
+  optimizer_runs = 2
   out = "out"
   solc_version = "0.8.30"
   src = "src"

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
   libs = ["lib"]
   optimizer = true
-  optimizer_runs = 2
+  optimizer_runs = 1
   out = "out"
   solc_version = "0.8.30"
   src = "src"

--- a/src/Market.sol
+++ b/src/Market.sol
@@ -267,13 +267,13 @@ contract Market is
 
     // Cancel limit orders and taker queue entries
     {
-      uint32[] memory ids = userOrders[trader];
-      for (uint256 k; k < ids.length; ++k) {
-        uint32 id = ids[k];
+      uint32[] memory orderIds = userOrders[trader];
+      for (uint256 k; k < orderIds.length; ++k) {
+        uint32 id = orderIds[k];
         if (ob[activeCycle].makerNodes[id].trader == trader) _forceCancel(id);
       }
 
-      // Clear user's order tracking
+      // Clear all taker queue entries for this trader
       _clearTakerQueueEntries(trader);
 
       // Clear user's order tracking


### PR DESCRIPTION
- Moves any existing longs (after netting) to feeRecipient. Liquidated user can't benefit from any longs. Can never have positive pnl
- Can get negative pnl, and this happens when marked for liquidation but orders not filled, and price continues to move in unfavourable direction